### PR TITLE
fix: initial network state was not detected

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1323,6 +1323,7 @@ impl PacketApplicationWindow {
         let imp = self.imp();
 
         let (tx, mut network_rx) = watch::channel(false);
+        let tx_clone = tx.clone(); // Clone network tx for initial state update
         imp.network_monitor
             .connect_network_changed(move |monitor, _| {
                 _ = tx.send(monitor.is_network_available());
@@ -1417,6 +1418,7 @@ impl PacketApplicationWindow {
                 ));
             }
         ));
+        tx_clone.send(imp.network_monitor.is_network_available()); // Updates network state on startup
     }
 
     fn setup_rqs_service(&self) -> glib::JoinHandle<()> {


### PR DESCRIPTION
On startup, Wi-Fi connectivity was not reflected properly unless there was a network state change. This fixes it.

See: https://github.com/NixOS/nixpkgs/pull/413357