### PR TITLE
Add FileNotFoundError handling in nautilus extension

### DIFF
--- a/data/resources/plugins/packet_nautilus.py.in
+++ b/data/resources/plugins/packet_nautilus.py.in
@@ -31,7 +31,7 @@ def init_i18n() -> gettext.NullTranslations | gettext.GNUTranslations:
         flatpak_info = subprocess.run(
             ["flatpak", "info", "-l", APP_ID], capture_output=True, check=True
         )
-    except subprocess.CalledProcessError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         pass
 
     if flatpak_info:


### PR DESCRIPTION
```
 6월 12 12:37:37 acrux nautilus[3200]: Traceback (most recent call last):
 6월 12 12:37:37 acrux nautilus[3200]:   File "/home/honnip/.nix-profile/share/nautilus-python/extensions/packet_nautilus.py", line 60, in <module>
 6월 12 12:37:37 acrux nautilus[3200]:     i18n = init_i18n()
 6월 12 12:37:37 acrux nautilus[3200]:            ^^^^^^^^^^^
 6월 12 12:37:37 acrux nautilus[3200]:   File "/home/honnip/.nix-profile/share/nautilus-python/extensions/packet_nautilus.py", line 32, in init_i18n
 6월 12 12:37:37 acrux nautilus[3200]:     flatpak_info = subprocess.run(
 6월 12 12:37:37 acrux nautilus[3200]:                    ^^^^^^^^^^^^^^^
 6월 12 12:37:37 acrux nautilus[3200]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/subprocess.py", line 548, in run
 6월 12 12:37:37 acrux nautilus[3200]:     with Popen(*popenargs, **kwargs) as process:
 6월 12 12:37:37 acrux nautilus[3200]:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6월 12 12:37:37 acrux nautilus[3200]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/subprocess.py", line 1026, in __init__
 6월 12 12:37:37 acrux nautilus[3200]:     self._execute_child(args, executable, preexec_fn, close_fds,
 6월 12 12:37:37 acrux nautilus[3200]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/subprocess.py", line 1955, in _execute_child
 6월 12 12:37:37 acrux nautilus[3200]:     raise child_exception_type(errno_num, err_msg, err_filename)
 6월 12 12:37:37 acrux nautilus[3200]: FileNotFoundError: [Errno 2] No such file or directory: 'flatpak'
```

It fails on systems where flatpak is not installed.

I think the error raised before the process is executed.. but I'm not sure.