### PR TITLE
WIP - Enable macos build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /.flatpak/
 /vendor
 /.vscode
+.idea
 
 /subprojects/blueprint-compiler
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,10 +43,6 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "gdk4-wayland",
- "gdk4-x11",
- "glib",
- "gtk4",
  "rand",
  "serde",
  "serde_repr",
@@ -1091,55 +1087,6 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
-]
-
-[[package]]
-name = "gdk4-wayland"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd34518488cd624a85e75e82540bc24c72cfeb0aea6bad7faed683ca3977dba0"
-dependencies = [
- "gdk4",
- "gdk4-wayland-sys",
- "gio",
- "glib",
- "libc",
-]
-
-[[package]]
-name = "gdk4-wayland-sys"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7a0f2332c531d62ee3f14f5e839ac1abac59e9b052adf1495124c00d89a34b"
-dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gdk4-x11"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3e7380a9a206b170e1b52b5f25581406db816c68f4e7140dbef89a9e5b52ac"
-dependencies = [
- "gdk4",
- "gdk4-x11-sys",
- "gio",
- "glib",
- "libc",
-]
-
-[[package]]
-name = "gdk4-x11-sys"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070bd50a053f90d7fdf6be1d75672ea0f97c0e5da3a10dc6d02e5defcb0db32f"
-dependencies = [
- "gdk4-sys",
- "glib-sys",
- "libc",
  "system-deps",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ zbus = "5.7.1"
 futures-lite = "2.6.0"
 ashpd = { version = "0.11.0", default-features = false, features = [
     "async-std",
-    "gtk4",
 ] }
 futures-timer = "3.0.3"
 tokio-util = "0.7.15"

--- a/src/application.rs
+++ b/src/application.rs
@@ -72,6 +72,11 @@ mod imp {
 
         fn startup(&self) {
             debug!("GtkApplication<PacketApplication>::startup");
+            
+            // Restrict GDK to only use the macOS backend to avoid X11/Wayland dependencies
+            #[cfg(target_os = "macos")]
+            gdk::set_allowed_backends("macos");
+            
             self.parent_startup();
             let app = self.obj();
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -922,7 +922,6 @@ impl PacketApplicationWindow {
         let imp = self.imp();
 
         let response = Background::request()
-            .identifier(ashpd::WindowIdentifier::from_native(&self.native().unwrap()).await)
             .auto_start(self.imp().settings.boolean("auto-start"))
             .command(["packet", "--background"])
             .dbus_activatable(false)


### PR DESCRIPTION
This PR has changed that were required (for me) to enable building and running on macos.

I know little about gtk on macos and less about packet, so I let Cursor guide me in a number of changes.

I will try to build this on a linux machine of mine, and check that the changes don't break it.

There remains an issue with image resource loading that I need to work on.

I have checked it works by sharing files to and from an Android device