### PR TITLE
Update flatpak GNOME runtime 48 to 49 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   flatpak:
     name: Flatpak
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
       options: --privileged
     strategy:
       matrix:


### PR DESCRIPTION
### Description

As the GNOME 48 runtime is now EOL, with the availability of GNOME 50, there are now console warnings about packet using the 48 runtime. It appears the application itself was already updated to use GNOME 49 runtime in https://github.com/nozwock/packet/commit/5da36f043fbb9aed2875e5f99c69ef3171d9d24e but the Flatpak GNOME runtime is still 48. Thus, this PR bumps the Flatpak GNOME runtime form 48 to 49.

Resolves https://github.com/nozwock/packet/issues/132

### Testing

Unfortunately as the change is at the GitHub CI Flatpak build step I'm unable to test this change. That said, as I mentioned, the application is already based on GNOME 49, it's just the Flatpak container that is still 48. Therefore, I expect everything to just work :tm: .

### Notes

A potential follow up effort could be to update all of the aforementione from GNOME 49 to 50.

